### PR TITLE
Remover ponto equivocado no YAML file

### DIFF
--- a/manuscript/compose.md
+++ b/manuscript/compose.md
@@ -24,7 +24,7 @@ Cada linha desse arquivo pode ser definida com uma chave valor ou uma lista. Vam
 version: '2'
 services:
   web:
-    build: .
+    build:
       context: ./dir
       dockerfile: Dockerfile-alternate
       args:


### PR DESCRIPTION
Quando criamos dicionários no YAML não podemos colocar um valor na chave padrão.

http://www.yaml.org/spec/1.2/spec.html#mapping/