### PR TITLE
Corrigindo link quebrado em servicosdeapoio.md

### DIFF
--- a/manuscript/servicosdeapoio.md
+++ b/manuscript/servicosdeapoio.md
@@ -1,6 +1,6 @@
 # Serviços de Apoio
 
-Seguindo a lista do modelo [12factor](http://12factor.net/pt_br), temos **“Serviços de Apoio”** como quarta boa prática.
+Seguindo a lista do modelo [12factor](http://12factor.net/pt_br/), temos **“Serviços de Apoio”** como quarta boa prática.
 
 Para contextualizar, "serviços de apoio" é qualquer aplicação que seu código consome para operar corretamente (Ex.: banco de dados, serviço de mensagens e afins).
 


### PR DESCRIPTION
O link para http://12factor.net/pt_br está quebrado, modificado para http://12factor.net/pt_br/