### PR TITLE
fix error while generating page 'comandos_uteis.md'

### DIFF
--- a/manuscript/comandos_uteis.md
+++ b/manuscript/comandos_uteis.md
@@ -11,4 +11,4 @@ Seguem alguns comandos úteis e simples abaixo:
 -   Remove volumes "órfãos"  
 `docker volume prune`
 -   Mostra uso de recursos dos containers rodando  
-`docker stats $(docker ps --format {{.Names}})`
+`docker stats $(docker ps --format {{Names}})`


### PR DESCRIPTION
Ao rodar gitbook build dava erro por causa do ".". Porém achei que deveria carregar algum conteúdo e que {{Names}} seria uma variável mas ficou em branco.

![image](https://user-images.githubusercontent.com/2377568/52028485-f521e880-24ed-11e9-9453-fc55950d94fe.png)
