### PR TITLE
Adicionar comando útil - docker cp

### DIFF
--- a/manuscript/comandos_uteis.md
+++ b/manuscript/comandos_uteis.md
@@ -20,3 +20,9 @@ Seguem alguns comandos úteis e simples abaixo:
 `docker save -o imagem.docker imagem`
 -   Carregar imagem  
 `docker load -i imagem.docker`
+-   Copiar arquivos/diretórios da máquina local para dentro de um contêiner  
+`docker cp /home/app meu_container:/app/`
+
+
+
+


### PR DESCRIPTION
Adicionar comando docker cp com exemplo de cópia de diretório da máquina local para o container