### PR TITLE
Fix instalação - comando e versão do docker machine 

### DIFF
--- a/manuscript/instalacao.md
+++ b/manuscript/instalacao.md
@@ -79,7 +79,7 @@ sudo su - root
 Execute o comando abaixo:
 
 ```
-$ curl -L https://github.com/docker/machine/releases/download/v0.10.0/docker-machine-`uname -s`-`uname -m` > /usr/local/bin/docker-machine && \
+curl -L https://github.com/docker/machine/releases/download/v0.16.2/docker-machine-`uname -s`-`uname -m` > /usr/local/bin/docker-machine && \
 chmod +x /usr/local/bin/docker-machine
 ```
 Para testar, execute o comando abaixo:


### PR DESCRIPTION
Foi removido o cifrão do começo do comando (já que ele é executado como root) e foi atualizado a versão do docker machine (v0.16.2)